### PR TITLE
chore: timestamp를 KST 기준으로 변경

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -21,9 +21,12 @@ app.post('/api/analytics/collect', async (req, res) => {
     const db = await connectMongo();
     const logs = db.collection('logs');
 
+    const UstTime = new Date(data.timestamp);
+    const kstTime = UstTime.toLocaleString("ko-KR", { timeZone: "Asia/Seoul" }); // UST → KST로 변경
+
     await logs.insertOne({
       event_name: data.event_name,
-      timestamp: data.timestamp,
+      timestamp: kstTime, // data.timestamp
       client_id: data.client_id,
       user_id: data.user_id,
       session_id: data.session_id,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>KlickLab</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/ui/Sidebar.tsx
+++ b/frontend/src/components/ui/Sidebar.tsx
@@ -141,7 +141,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         <div className="p-4 border-t border-gray-200">
           <div className="text-xs text-gray-500">
             <div>버전 1.0.0</div>
-            <div>© 2024 KlickLab</div>
+            <div>© 2025 KlickLab</div>
           </div>
         </div>
       )}


### PR DESCRIPTION
- 로그 DB에 저장되는 `timestamp`를 UST에서 KST로 변경
- 프론트 타이틀을 `KlickLab`으로 변경
- 사이드바 하단에서 2024 → 2025로 변경